### PR TITLE
Added support for toRelativeString()

### DIFF
--- a/src/xdate.js
+++ b/src/xdate.js
@@ -440,6 +440,79 @@ proto.toISOString = function() {
 	return this.toUTCString(ISO_FORMAT_STRING_TZ);
 };
 
+proto.toRelativeString = function(unit) {
+  var relativeString = '';
+  var unitString = '';
+  var magnitude = 0;
+  var now = new XDate();
+  switch (unit) {
+    case 'y':
+      unitString = 'years';
+      magnitude = this.diffYears( now );
+    break;
+
+    case 'M':
+      unitString = 'months';
+      magnitude = this.diffMonths( now );
+    break;
+
+    case 'd':
+      unitString = 'days';
+      magnitude = this.diffDays( now );
+    break;
+
+    case 'h':
+      unitString = 'hours';
+      magnitude = this.diffHours( now );
+    break;
+
+    case 'm':
+      unitString = 'minutes';
+      magnitude = this.diffMinutes( now );
+    break;
+
+    case 's':
+      unitString = 'seconds';
+      magnitude = this.diffSeconds( now );
+    break;
+
+    case 'ms':
+      unitString = 'milliseconds';
+      magnitude = this.diffMilliseconds( now );
+    break;
+
+    // Use whichever unit yields the lowest magnitude greater than 1
+    default:
+      if (Math.abs(magnitude = this.diffYears( now )) > 1)             unitString = 'years';
+      else if (Math.abs(magnitude = this.diffMonths( now )) > 1)       unitString = 'months';
+      else if (Math.abs(magnitude = this.diffDays( now )) > 1)         unitString = 'days';
+      else if (Math.abs(magnitude = this.diffHours( now )) > 1)        unitString = 'hours';
+      else if (Math.abs(magnitude = this.diffMinutes( now )) > 1)      unitString = 'minutes';
+      else if (Math.abs(magnitude = this.diffSeconds( now )) > 1)      unitString = 'seconds';
+      else if (Math.abs(magnitude = this.diffMilliseconds( now )) > 1) unitString = 'milliseconds';
+      else                                                             magnitude = 0;
+    break;
+  }
+
+  magnitude = parseInt( magnitude );
+
+  if (magnitude == 1 || magnitude == 0) {
+    unitString = unitString.slice(0, -1);
+  }
+
+  if (magnitude > 0) {
+    relativeString = magnitude + ' ' + unitString + ' ago';
+  }
+  else if (magnitude < 0) {
+    relativeString = 'in ' + Math.abs(magnitude) + ' ' + unitString;
+  }
+  else {
+    relativeString = 'within the past ' + unitString;
+  }
+
+  return relativeString;
+}
+
 
 XDate.defaultLocale = '';
 XDate.locales = {


### PR DESCRIPTION
Added a method to the prototype called toRelativeString() per issue #10 (and #12)

Let me know if there's anything related to this that should or could be included. I thought about adding a second parameter to set the precision or something which might be useful if someone always wanted the date in years but also wanted a tenths fraction included.

Another use case I could see would be "X years Y months ago". Perhaps the first argument could be set up to take in a prints type formatted string and the function could detect the units by inspecting the closest proceeding word? Does anyone have any feelings about this ( @powmedia ) ?
