### PR TITLE
Added getMonthWeeks method and spanish locale

### DIFF
--- a/src/xdate.js
+++ b/src/xdate.js
@@ -291,6 +291,11 @@ proto.getUTCWeek = function() {
 };
 
 
+proto.getMonthWeeks = function() {
+	return _getMonthWeeks(this);
+};
+
+
 proto.setWeek = function(n, year) {
 	_setWeek(this, n, year, false);
 	return this; // for chaining
@@ -318,6 +323,11 @@ function _getWeek(getField) {
 }
 
 
+function _getMonthWeeks(xdate) {
+	return getMonthWeeks(xdate);
+}
+
+
 function getWeek(year, month, date) {
 	var d = new Date(UTC(year, month, date));
 	var currentWeek1 = getWeek1(year);
@@ -338,6 +348,35 @@ function getWeek1(year) { // returns Date of first week of year, in UTC
 	var d = new Date(UTC(year, 0, 4));
 	d.setUTCDate(d.getUTCDate() - (d.getUTCDay() + 6) % 7); // make it Monday of the week
 	return d;
+}
+
+
+function getMonthWeeks(xdate) {
+	var locales = XDate.locales;
+	var defaultLocaleSettings = locales[XDate.defaultLocale] || {};
+	
+	var first = xdate.clone();
+	first = first.setDate(1).addDays(defaultLocaleSettings.firstDay - first.getDay());	
+	
+	var last = xdate.clone();
+	last = last.setDate(1).addMonths(1).addDays(-1).addDays(defaultLocaleSettings.firstDay + 6 - last.getDay());
+	
+	weeks = Math.ceil(first.diffWeeks(last));
+	var weeksDays = [];
+	var positionDate = first.clone();
+	
+	for(var i = 0; i < weeks; i++) {
+		weeksDays[i] = [];
+		for(var j = 0; j < 7; j++) {
+			weeksDays[i].push(positionDate.clone());
+			positionDate.addDays(1);
+		}
+		if(positionDate.getMonth() != xdate.getMonth()) {
+			i = weeks;	
+		}
+	}
+	
+	return weeksDays;
 }
 
 
@@ -449,7 +488,17 @@ XDate.locales = {
 		dayNames: ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'],
 		dayNamesShort: ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'],
 		amDesignator: 'AM',
-		pmDesignator: 'PM'
+		pmDesignator: 'PM',
+		firstDay: 0
+	},
+	'es': {
+		monthNames: ['Enero','Febrero','Marzo','Abril','Mayo','Junio','Julio','Augosto','Septimbre','Octubre','Noviembre','Diciembre'],
+		monthNamesShort: ['Ene','Feb','Mar','Abr','May','Jun','Jul','Ago','Sep','Oct','Nov','Dic'],
+		dayNames: ['Domingo','Lunes','Martes','Miercoles','Jueves','Viernes','Sabado'],
+		dayNamesShort: ['Dom','Lun','Mar','Mie','Jue','Vie','Sab'],
+		amDesignator: 'AM',
+		pmDesignator: 'PM',
+		firstDay: 1
 	}
 };
 XDate.formatters = {

--- a/test/getters.js
+++ b/test/getters.js
@@ -69,3 +69,7 @@ test("getWeek/getUTCWeek mega-test", function() {
 	}
 	return true;
 });
+
+test("getMonthWeeks", function() {
+	return (new XDate(2012, 10, 1).getMonthWeeks().length == 5 && new XDate(2012, 11, 1).getMonthWeeks().length == 6 && new XDate(2021, 1, 1).getMonthWeeks().length == 4);
+});


### PR DESCRIPTION
Spanish locale added with all days and month translated. Added a new feature firstDay to indicate what day is the first day of the week. In England the week start on Sunday. In Spain the week start on Monday.
The getMonthWeek method return a week array in a month and any week have a 7 days array started in firstDay locale configuration.
