### PR TITLE
Exposing getWeekYear

### DIFF
--- a/src/xdate.js
+++ b/src/xdate.js
@@ -303,6 +303,16 @@ proto.getUTCWeek = function() {
 };
 
 
+proto.getWeekYear = function() {
+	return _getWeekYear(curry(_getField, this, false));
+};
+
+
+proto.getUTCWeekYear = function() {
+	return _getWeekYear(curry(_getField, this, true));
+};
+
+
 proto.setWeek = function(n, year) {
 	_setWeek(this, n, year, false);
 	return this; // for chaining
@@ -336,6 +346,11 @@ function getWeek(year, month, date) {
 		getWeekYear(year, month, date)
 	);
 	return Math.floor(Math.round((d - week1) / DAY_MS) / 7) + 1;
+}
+
+
+function _getWeekYear(getField) {
+	return getWeekYear(getField(FULLYEAR), getField(MONTH), getField(DATE));
 }
 
 
@@ -590,7 +605,9 @@ function getTokenReplacement(xdate, token, getField, getSetting, useUTC) {
 		case 'zzz'  : return useUTC ? 'Z' : _getTZString(xdate, token);
 		case 'w'    : return _getWeek(getField);
 		case 'ww'   : return zeroPad(_getWeek(getField));
-		case 'S'    :
+		case 'jj'		: return (_getWeekYear(getField)+'').substring(2);
+		case 'jjjj' : return _getWeekYear(getField);
+		case 'S'    : 
 			var d = getField(DATE);
 			if (d > 10 && d < 20) return 'th';
 			return ['st', 'nd', 'rd'][d % 10 - 1] || 'th';

--- a/test/formatting.js
+++ b/test/formatting.js
@@ -59,6 +59,16 @@ test("long names", function() {
 		.toString('dddd, MMMM dd, yyyy') == "Saturday, November 05, 2011";
 });
 
+test("week year, two digits", function() {
+	return new XDate(2012, 12, 31)
+		.toString('jj') == '13';
+});
+
+test("week year, four digits", function() {
+	return new XDate(2012, 12, 31)
+		.toString('jjjj') == '2013';
+});
+
 
 test("ordinals", function() {
 	return new XDate(2011, 1, 1).toString('dS') == "1st" &&

--- a/test/getters.js
+++ b/test/getters.js
@@ -69,3 +69,11 @@ test("getWeek/getUTCWeek mega-test", function() {
 	}
 	return true;
 });
+
+test("getWeekYear", function() {
+	return new XDate(2012, 12, 31).getWeekYear() == 2013;
+});
+
+test("getUTCWeekYear", function() {
+	return new XDate(2012, 12, 31, 12, 30).getUTCWeekYear() == 2013;
+});


### PR DESCRIPTION
Hi,

I needed the getWeekYear function displaying the current week including the year, so I've made the method publicly available in the XDate prototype. I've also added two formats for displaying the week year (`jj` and `jjjj`).

Kind regards,

Fred Oranje
